### PR TITLE
fix: Restart fastapi service after deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,5 @@ jobs:
                   python3 -m venv venv
                   source venv/bin/activate
                   pip3 install -r requirements.txt
-                  sudo -S <<< $EC2_USER_PASSWORD systemctl start fastapi-book-project.service
+                  sudo -S <<< $EC2_USER_PASSWORD systemctl restart fastapi-book-project.service
                   sudo -S <<< $EC2_USER_PASSWORD systemctl status fastapi-book-project.service

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ uvicorn main:app
 
 ## API Endpoints
 
+### Base URL
+- [http://ec2-18-232-125-167.compute-1.amazonaws.com/](http://ec2-18-232-125-167.compute-1.amazonaws.com/) 
+
 ### Books
 
 - `GET /api/v1/books/` - Get all books
@@ -128,6 +131,9 @@ The API includes proper error handling for:
 - Invalid book IDs
 - Invalid genre types
 - Malformed requests
+
+## Deployment
+To deploy new changes merge the changes to the main branch. Once merged the deployment will take place automatically and the main branch will update whatever is in the production environment.
 
 ## Contributing
 

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -55,7 +55,7 @@ async def get_book(book_id: int) -> Book:
     if (book == None):
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
-            content= 'Book not Found.'
+            content= {'detail' : 'Book not Found'}
         )
     
     return JSONResponse(

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -55,7 +55,7 @@ async def get_book(book_id: int) -> Book:
     if (book == None):
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
-            content= {'detail' : 'Book not Found'}
+            content= {"detail" : "Book not Found"}
         )
     
     return JSONResponse(


### PR DESCRIPTION
# What
- Replaced the start keyword with the restart keyword, in the linux command that runs the fastapi service.

# Why
- The fastapi service did not restart after deployment
- This led to the cold in memory being run, even when we had pushed some new changes.

# How
- By calling `sudo -S <<< $EC2_USER_PASSWORD systemctl restart fastapi-book-project.service` instead of `sudo -S <<< $EC2_USER_PASSWORD systemctl start fastapi-book-project.service`